### PR TITLE
Update usage of memcpy for Swift 1.2

### DIFF
--- a/GlimpseXML/GlimpseXML.swift
+++ b/GlimpseXML/GlimpseXML.swift
@@ -730,7 +730,7 @@ private func stringFromFixedCString(cs: UnsafePointer<CChar>, length: Int) -> St
     // taken from <http://stackoverflow.com/questions/25042695/swift-converting-from-unsafepointeruint8-with-length-to-string>
     let buflen = length + 1
     var buf = UnsafeMutablePointer<CChar>.alloc(buflen)
-    memcpy(buf, cs, UInt(length))
+    memcpy(buf, cs, length)
     buf[length] = 0 // zero terminate
     let s = String.fromCString(buf)
     buf.dealloc(buflen)


### PR DESCRIPTION
- `memcpy` api changed to accept just an Int
